### PR TITLE
Extract a GrDynamicRectanize class from GrDynamicAtlas

### DIFF
--- a/gn/gpu.gni
+++ b/gn/gpu.gni
@@ -91,6 +91,8 @@ skia_gpu_sources = [
   "$_src/gpu/GrDstProxyView.h",
   "$_src/gpu/GrDynamicAtlas.cpp",
   "$_src/gpu/GrDynamicAtlas.h",
+  "$_src/gpu/GrDynamicRectanizer.cpp",
+  "$_src/gpu/GrDynamicRectanizer.h",
   "$_src/gpu/GrEagerVertexAllocator.cpp",
   "$_src/gpu/GrEagerVertexAllocator.h",
   "$_src/gpu/GrFinishCallbacks.cpp",

--- a/src/gpu/GrDynamicAtlas.cpp
+++ b/src/gpu/GrDynamicAtlas.cpp
@@ -18,44 +18,12 @@
 #include "src/gpu/GrSurfaceProxyPriv.h"
 #include "src/gpu/GrSurfaceProxyView.h"
 
-// Each Node covers a sub-rectangle of the final atlas. When a GrDynamicAtlas runs out of room, we
-// create a new Node the same size as all combined nodes in the atlas as-is, and then place the new
-// Node immediately below or beside the others (thereby doubling the size of the GyDynamicAtlas).
-class GrDynamicAtlas::Node {
-public:
-    Node(Node* previous, GrRectanizer* rectanizer, int x, int y)
-            : fPrevious(previous), fRectanizer(rectanizer), fX(x), fY(y) {}
-
-    Node* previous() const { return fPrevious; }
-
-    bool addRect(int w, int h, SkIPoint16* loc) {
-        // Pad all paths except those that are expected to take up an entire physical texture.
-        if (w < fRectanizer->width()) {
-            w = std::min(w + kPadding, fRectanizer->width());
-        }
-        if (h < fRectanizer->height()) {
-            h = std::min(h + kPadding, fRectanizer->height());
-        }
-        if (!fRectanizer->addRect(w, h, loc)) {
-            return false;
-        }
-        loc->fX += fX;
-        loc->fY += fY;
-        return true;
-    }
-
-private:
-    Node* const fPrevious;
-    GrRectanizer* const fRectanizer;
-    const int fX, fY;
-};
-
-sk_sp<GrTextureProxy> GrDynamicAtlas::MakeLazyAtlasProxy(
-        LazyInstantiateAtlasCallback&& callback,
-        GrColorType colorType,
-        InternalMultisample internalMultisample,
-        const GrCaps& caps,
-        GrSurfaceProxy::UseAllocator useAllocator) {
+sk_sp<GrTextureProxy>
+GrDynamicAtlas::MakeLazyAtlasProxy(LazyInstantiateAtlasCallback&& callback,
+                                   GrColorType colorType,
+                                   InternalMultisample internalMultisample,
+                                   const GrCaps& caps,
+                                   GrSurfaceProxy::UseAllocator useAllocator) {
     GrBackendFormat format = caps.getDefaultBackendFormat(colorType, GrRenderable::kYes);
 
     int sampleCount = 1;
@@ -63,142 +31,87 @@ sk_sp<GrTextureProxy> GrDynamicAtlas::MakeLazyAtlasProxy(
         sampleCount = caps.internalMultisampleCount(format);
     }
 
-    sk_sp<GrTextureProxy> proxy =
-            GrProxyProvider::MakeFullyLazyProxy(std::move(callback), format, GrRenderable::kYes,
-                                                sampleCount, GrProtected::kNo, caps, useAllocator);
+    sk_sp<GrTextureProxy> proxy = GrProxyProvider::MakeFullyLazyProxy(std::move(callback),
+                                                                      format,
+                                                                      GrRenderable::kYes,
+                                                                      sampleCount,
+                                                                      GrProtected::kNo,
+                                                                      caps,
+                                                                      useAllocator);
 
     return proxy;
 }
 
-GrDynamicAtlas::GrDynamicAtlas(GrColorType colorType, InternalMultisample internalMultisample,
-                               SkISize initialSize, int maxAtlasSize, const GrCaps& caps,
-                               RectanizerAlgorithm algorithm)
-        : fColorType(colorType)
-        , fInternalMultisample(internalMultisample)
-        , fMaxAtlasSize(maxAtlasSize)
-        , fRectanizerAlgorithm(algorithm) {
-    SkASSERT(fMaxAtlasSize <= caps.maxTextureSize());
+GrDynamicAtlas::GrDynamicAtlas(GrColorType colorType,
+                               InternalMultisample internalMultisample,
+                               SkISize initialSize,
+                               int maxAtlasSize,
+                               const GrCaps& caps,
+                               RectanizerAlgorithm algorithm) :
+    fColorType(colorType),
+    fInternalMultisample(internalMultisample),
+    fDynamicRectanizer(initialSize, maxAtlasSize, algorithm) {
+    SkASSERT(fDynamicRectanizer.maxAtlasSize() <= caps.maxTextureSize());
     this->reset(initialSize, caps);
 }
 
-GrDynamicAtlas::~GrDynamicAtlas() {
-}
+GrDynamicAtlas::~GrDynamicAtlas() {}
 
 void GrDynamicAtlas::reset(SkISize initialSize, const GrCaps& caps) {
-    fNodeAllocator.reset();
-    fWidth = std::min(SkNextPow2(initialSize.width()), fMaxAtlasSize);
-    fHeight = std::min(SkNextPow2(initialSize.height()), fMaxAtlasSize);
-    fTopNode = nullptr;
-    fDrawBounds.setEmpty();
+    fDynamicRectanizer.reset(initialSize);
     fTextureProxy = MakeLazyAtlasProxy(
-            [this](GrResourceProvider* resourceProvider, const LazyAtlasDesc& desc) {
-                if (!fBackingTexture) {
-                    fBackingTexture = resourceProvider->createTexture(
-                            fTextureProxy->backingStoreDimensions(),
-                            desc.fFormat,
-                            desc.fTextureType,
-                            desc.fRenderable,
-                            desc.fSampleCnt,
-                            desc.fMipmapped,
-                            desc.fBudgeted,
-                            desc.fProtected);
-                }
-                return GrSurfaceProxy::LazyCallbackResult(fBackingTexture);
-            },
-            fColorType, fInternalMultisample, caps, GrSurfaceProxy::UseAllocator::kNo);
+        [this](GrResourceProvider* resourceProvider, const LazyAtlasDesc& desc) {
+            if (!fBackingTexture) {
+                fBackingTexture =
+                    resourceProvider->createTexture(fTextureProxy->backingStoreDimensions(),
+                                                    desc.fFormat,
+                                                    desc.fTextureType,
+                                                    desc.fRenderable,
+                                                    desc.fSampleCnt,
+                                                    desc.fMipmapped,
+                                                    desc.fBudgeted,
+                                                    desc.fProtected);
+            }
+            return GrSurfaceProxy::LazyCallbackResult(fBackingTexture);
+        },
+        fColorType,
+        fInternalMultisample,
+        caps,
+        GrSurfaceProxy::UseAllocator::kNo);
     fBackingTexture = nullptr;
 }
 
-GrDynamicAtlas::Node* GrDynamicAtlas::makeNode(Node* previous, int l, int t, int r, int b) {
-    int width = r - l;
-    int height = b - t;
-    GrRectanizer* rectanizer = (fRectanizerAlgorithm == RectanizerAlgorithm::kSkyline)
-            ? (GrRectanizer*)fNodeAllocator.make<GrRectanizerSkyline>(width, height)
-            : fNodeAllocator.make<GrRectanizerPow2>(width, height);
-    return fNodeAllocator.make<Node>(previous, rectanizer, l, t);
-}
-
 GrSurfaceProxyView GrDynamicAtlas::readView(const GrCaps& caps) const {
-    return {fTextureProxy, kTextureOrigin,
+    return {fTextureProxy,
+            kTextureOrigin,
             caps.getReadSwizzle(fTextureProxy->backendFormat(), fColorType)};
 }
 
 GrSurfaceProxyView GrDynamicAtlas::writeView(const GrCaps& caps) const {
-    return {fTextureProxy, kTextureOrigin,
+    return {fTextureProxy,
+            kTextureOrigin,
             caps.getWriteSwizzle(fTextureProxy->backendFormat(), fColorType)};
 }
 
 bool GrDynamicAtlas::addRect(int width, int height, SkIPoint16* location) {
-    // This can't be called anymore once instantiate() has been called.
-    SkASSERT(!this->isInstantiated());
-
-    if (!this->internalPlaceRect(width, height, location)) {
-        return false;
-    }
-
-    fDrawBounds.fWidth = std::max(fDrawBounds.width(), location->x() + width);
-    fDrawBounds.fHeight = std::max(fDrawBounds.height(), location->y() + height);
-    return true;
-}
-
-bool GrDynamicAtlas::internalPlaceRect(int w, int h, SkIPoint16* loc) {
-    if (std::max(h, w) > fMaxAtlasSize) {
-        return false;
-    }
-    if (std::min(h, w) <= 0) {
-        loc->set(0, 0);
-        return true;
-    }
-
-    if (!fTopNode) {
-        if (w > fWidth) {
-            fWidth = std::min(SkNextPow2(w), fMaxAtlasSize);
-        }
-        if (h > fHeight) {
-            fHeight = std::min(SkNextPow2(h), fMaxAtlasSize);
-        }
-        fTopNode = this->makeNode(nullptr, 0, 0, fWidth, fHeight);
-    }
-
-    for (Node* node = fTopNode; node; node = node->previous()) {
-        if (node->addRect(w, h, loc)) {
-            return true;
-        }
-    }
-
-    // The rect didn't fit. Grow the atlas and try again.
-    do {
-        if (fWidth >= fMaxAtlasSize && fHeight >= fMaxAtlasSize) {
-            return false;
-        }
-        if (fHeight <= fWidth) {
-            int top = fHeight;
-            fHeight = std::min(fHeight * 2, fMaxAtlasSize);
-            fTopNode = this->makeNode(fTopNode, 0, top, fWidth, fHeight);
-        } else {
-            int left = fWidth;
-            fWidth = std::min(fWidth * 2, fMaxAtlasSize);
-            fTopNode = this->makeNode(fTopNode, left, 0, fWidth, fHeight);
-        }
-    } while (!fTopNode->addRect(w, h, loc));
-
-    return true;
+    return fDynamicRectanizer.addRect(width, height, location);
 }
 
 void GrDynamicAtlas::instantiate(GrOnFlushResourceProvider* onFlushRP,
                                  sk_sp<GrTexture> backingTexture) {
-    SkASSERT(!this->isInstantiated());  // This method should only be called once.
+    SkASSERT(!this->isInstantiated()); // This method should only be called once.
     // Caller should have cropped any paths to the destination render target instead of asking for
     // an atlas larger than maxRenderTargetSize.
-    SkASSERT(std::max(fHeight, fWidth) <= fMaxAtlasSize);
-    SkASSERT(fMaxAtlasSize <= onFlushRP->caps()->maxRenderTargetSize());
+    SkASSERT(std::max(fDynamicRectanizer.height(), fDynamicRectanizer.width()) <=
+             fDynamicRectanizer.maxAtlasSize());
+    SkASSERT(fDynamicRectanizer.maxAtlasSize() <= onFlushRP->caps()->maxRenderTargetSize());
 
     if (fTextureProxy->isFullyLazy()) {
         // Finalize the content size of our proxy. The GPU can potentially make optimizations if it
         // knows we only intend to write out a smaller sub-rectangle of the backing texture.
-        fTextureProxy->priv().setLazyDimensions(fDrawBounds);
+        fTextureProxy->priv().setLazyDimensions(fDynamicRectanizer.drawBounds());
     }
-    SkASSERT(fTextureProxy->dimensions() == fDrawBounds);
+    SkASSERT(fTextureProxy->dimensions() == fDynamicRectanizer.drawBounds());
 
     if (backingTexture) {
 #ifdef SK_DEBUG

--- a/src/gpu/GrDynamicRectanizer.cpp
+++ b/src/gpu/GrDynamicRectanizer.cpp
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2020 Google Inc.
+ *
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+#include "src/gpu/GrDynamicRectanizer.h"
+
+#include "src/core/SkIPoint16.h"
+#include "src/gpu/GrCaps.h"
+#include "src/gpu/GrOnFlushResourceProvider.h"
+#include "src/gpu/GrProxyProvider.h"
+#include "src/gpu/GrRectanizerPow2.h"
+#include "src/gpu/GrRectanizerSkyline.h"
+#include "src/gpu/GrRenderTarget.h"
+#include "src/gpu/GrResourceProvider.h"
+#include "src/gpu/GrSurfaceProxyPriv.h"
+#include "src/gpu/GrSurfaceProxyView.h"
+
+// Each Node covers a sub-rectangle of the final atlas. When a GrDynamicRectanizer runs out of room,
+// we create a new Node the same size as all combined nodes in the atlas as-is, and then place the
+// new Node immediately below or beside the others (thereby doubling the size of the
+// GyDynamicAtlas).
+class GrDynamicRectanizer::Node {
+public:
+    Node(Node* previous, GrRectanizer* rectanizer, int x, int y)
+            : fPrevious(previous), fRectanizer(rectanizer), fX(x), fY(y) {}
+
+    Node* previous() const { return fPrevious; }
+
+    bool addRect(int w, int h, SkIPoint16* loc) {
+        // Pad all paths except those that are expected to take up an entire physical texture.
+        if (w < fRectanizer->width()) {
+            w = std::min(w + kPadding, fRectanizer->width());
+        }
+        if (h < fRectanizer->height()) {
+            h = std::min(h + kPadding, fRectanizer->height());
+        }
+        if (!fRectanizer->addRect(w, h, loc)) {
+            return false;
+        }
+        loc->fX += fX;
+        loc->fY += fY;
+        return true;
+    }
+
+private:
+    Node* const fPrevious;
+    GrRectanizer* const fRectanizer;
+    const int fX, fY;
+};
+
+void GrDynamicRectanizer::reset(SkISize initialSize) {
+    fNodeAllocator.reset();
+    fWidth = std::min(SkNextPow2(initialSize.width()), fMaxAtlasSize);
+    fHeight = std::min(SkNextPow2(initialSize.height()), fMaxAtlasSize);
+    fTopNode = nullptr;
+    fDrawBounds.setEmpty();
+}
+
+GrDynamicRectanizer::Node* GrDynamicRectanizer::makeNode(
+        Node* previous, int l, int t, int r, int b) {
+    int width = r - l;
+    int height = b - t;
+    GrRectanizer* rectanizer =
+            (fRectanizerAlgorithm == RectanizerAlgorithm::kSkyline)
+                    ? (GrRectanizer*)fNodeAllocator.make<GrRectanizerSkyline>(width, height)
+                    : fNodeAllocator.make<GrRectanizerPow2>(width, height);
+    return fNodeAllocator.make<Node>(previous, rectanizer, l, t);
+}
+
+bool GrDynamicRectanizer::addRect(int width, int height, SkIPoint16* location) {
+    if (!this->internalPlaceRect(width, height, location)) {
+        return false;
+    }
+
+    fDrawBounds.fWidth = std::max(fDrawBounds.width(), location->x() + width);
+    fDrawBounds.fHeight = std::max(fDrawBounds.height(), location->y() + height);
+    return true;
+}
+
+bool GrDynamicRectanizer::internalPlaceRect(int w, int h, SkIPoint16* loc) {
+    if (std::max(h, w) > fMaxAtlasSize) {
+        return false;
+    }
+    if (std::min(h, w) <= 0) {
+        loc->set(0, 0);
+        return true;
+    }
+
+    if (!fTopNode) {
+        if (w > fWidth) {
+            fWidth = std::min(SkNextPow2(w), fMaxAtlasSize);
+        }
+        if (h > fHeight) {
+            fHeight = std::min(SkNextPow2(h), fMaxAtlasSize);
+        }
+        fTopNode = this->makeNode(nullptr, 0, 0, fWidth, fHeight);
+    }
+
+    for (Node* node = fTopNode; node; node = node->previous()) {
+        if (node->addRect(w, h, loc)) {
+            return true;
+        }
+    }
+
+    // The rect didn't fit. Grow the atlas and try again.
+    do {
+        if (fWidth >= fMaxAtlasSize && fHeight >= fMaxAtlasSize) {
+            return false;
+        }
+        if (fHeight <= fWidth) {
+            int top = fHeight;
+            fHeight = std::min(fHeight * 2, fMaxAtlasSize);
+            fTopNode = this->makeNode(fTopNode, 0, top, fWidth, fHeight);
+        } else {
+            int left = fWidth;
+            fWidth = std::min(fWidth * 2, fMaxAtlasSize);
+            fTopNode = this->makeNode(fTopNode, left, 0, fWidth, fHeight);
+        }
+    } while (!fTopNode->addRect(w, h, loc));
+
+    return true;
+}

--- a/src/gpu/GrDynamicRectanizer.h
+++ b/src/gpu/GrDynamicRectanizer.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2020 Google Inc.
+ *
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+#ifndef GrDynamicRectanizer_DEFINED
+#define GrDynamicRectanizer_DEFINED
+
+#include "include/core/SkSize.h"
+#include "src/core/SkArenaAlloc.h"
+
+struct SkIPoint16;
+struct SkIRect;
+
+/**
+ * This class implements a dynamic size GrRectanizer that grows until it reaches the implementation-
+ * dependent max texture size.
+ */
+class GrDynamicRectanizer {
+public:
+    inline static constexpr int kPadding = 1;  // Amount of padding below and to the right of each
+                                               // path.
+
+    enum class RectanizerAlgorithm { kSkyline, kPow2 };
+
+    GrDynamicRectanizer(SkISize initialSize,
+                        int maxAtlasSize,
+                        RectanizerAlgorithm algorithm = RectanizerAlgorithm::kSkyline)
+            : fMaxAtlasSize(maxAtlasSize), fRectanizerAlgorithm(algorithm) {
+        this->reset(initialSize);
+    }
+
+    void reset(SkISize initialSize);
+
+    int maxAtlasSize() const { return fMaxAtlasSize; }
+    int width() const { return fWidth; }
+    int height() const { return fHeight; }
+    const SkISize& drawBounds() const { return fDrawBounds; }
+
+    // Attempts to add a rect to the atlas. Returns true if successful, along with the rect's
+    // top-left location in the atlas.
+    bool addRect(int width, int height, SkIPoint16* location);
+
+private:
+    class Node;
+
+    Node* makeNode(Node* previous, int l, int t, int r, int b);
+    bool internalPlaceRect(int w, int h, SkIPoint16* loc);
+
+    const int fMaxAtlasSize;
+    const RectanizerAlgorithm fRectanizerAlgorithm;
+    int fWidth;
+    int fHeight;
+    SkISize fDrawBounds;
+
+    SkSTArenaAllocWithReset<512> fNodeAllocator;
+    Node* fTopNode = nullptr;
+};
+
+#endif


### PR DESCRIPTION
Allows us to use the atlas layout code without the texture proxy stuff.