### PR TITLE
Tweak path renderer heuristics

### DIFF
--- a/src/gpu/ops/AtlasPathRenderer.cpp
+++ b/src/gpu/ops/AtlasPathRenderer.cpp
@@ -90,8 +90,8 @@ constexpr static int kAtlasInitialSize = 512;
 // height, which lends very well to efficient pow2 atlas packing.
 constexpr static auto kAtlasAlgorithm = GrDynamicAtlas::RectanizerAlgorithm::kPow2;
 
-// Ensure every path in the atlas falls in or below the 256px high rectanizer band.
-constexpr static int kAtlasMaxPathHeight = 256;
+// Ensure every path in the atlas falls in or below the 512px high rectanizer band.
+constexpr static int kAtlasMaxPathHeight = 512;
 
 // If we have MSAA to fall back on, paths are already fast enough that we really only benefit from
 // atlasing when they are very small.

--- a/src/gpu/ops/TriangulatingPathRenderer.cpp
+++ b/src/gpu/ops/TriangulatingPathRenderer.cpp
@@ -33,7 +33,7 @@
 #include <cstdio>
 
 #ifndef GR_AA_TESSELLATOR_MAX_VERB_COUNT
-#define GR_AA_TESSELLATOR_MAX_VERB_COUNT 10
+#define GR_AA_TESSELLATOR_MAX_VERB_COUNT 1000
 #endif
 
 /*


### PR DESCRIPTION
* Move the atlas path renderer to the top of the chain. The batching
  abilities and low CPU footprint of this path renderer make it
  especially ideal for WASM/WebGL.

* Bump the atlas path renderer's max path height from 256 to 512. In
  WASM/WebGL, the CPU/mem bandwidth tradeoff skews more toward
  minimizing CPU load and putting more stress on memory bandwidth.

* Bump the AA triangulator's max verb count from 10 to 1000. This path
  renderer has always been under-utilized in Skia, IMO, when the only
  alternative is to render the path in software and upload a texture. In
  WASM, a software render is especially expensive. The type of paths
  created by Rive (fewer verbs that cover more length) are also the type
  of path that this path renderer is naturally good at.