### PR TITLE
Never reject an MSAA FBO0

### DIFF
--- a/src/gpu/GrCaps.h
+++ b/src/gpu/GrCaps.h
@@ -240,7 +240,16 @@ public:
     virtual bool isFormatAsColorTypeRenderable(GrColorType ct, const GrBackendFormat& format,
                                                int sampleCount = 1) const = 0;
 
+    virtual bool isRenderTargetAsColorTypeRenderable(GrColorType ct,
+                                                     const GrBackendRenderTarget& rt) const {
+        return this->isFormatAsColorTypeRenderable(ct, rt.getBackendFormat(), rt.sampleCnt());
+    }
+
     virtual bool isFormatRenderable(const GrBackendFormat& format, int sampleCount) const = 0;
+
+    virtual bool isRenderTargetRenderable(const GrBackendRenderTarget& rt) const {
+        return this->isFormatRenderable(rt.getBackendFormat(), rt.sampleCnt());
+    }
 
     // Find a sample count greater than or equal to the requested count which is supported for a
     // render target of the given format or 0 if no such sample count is supported. If the requested

--- a/src/gpu/GrGpu.cpp
+++ b/src/gpu/GrGpu.cpp
@@ -359,7 +359,7 @@ sk_sp<GrRenderTarget> GrGpu::wrapBackendRenderTarget(const GrBackendRenderTarget
 
     const GrCaps* caps = this->caps();
 
-    if (!caps->isFormatRenderable(backendRT.getBackendFormat(), backendRT.sampleCnt())) {
+    if (!caps->isRenderTargetRenderable(backendRT)) {
         return nullptr;
     }
 

--- a/src/gpu/gl/GrGLCaps.cpp
+++ b/src/gpu/gl/GrGLCaps.cpp
@@ -4481,6 +4481,20 @@ bool GrGLCaps::isFormatAsColorTypeRenderable(GrColorType ct, const GrBackendForm
     return this->isFormatRenderable(f, sampleCount);
 }
 
+bool GrGLCaps::isRenderTargetAsColorTypeRenderable(GrColorType ct,
+                                                   const GrBackendRenderTarget& rt) const {
+    int sampleCntToCheck;
+    GrGLFramebufferInfo fbi;
+    if (rt.getGLFramebufferInfo(&fbi) && fbi.fFBOID == 0) {
+        // FBO0 has different multisampling rules than offscreen render targets. If the user wrapped
+        // FBO0 and told us it's multisampled, just trust that the msaa is valid.
+        sampleCntToCheck = 1;
+    } else {
+        sampleCntToCheck = rt.sampleCnt();
+    }
+    return this->isFormatAsColorTypeRenderable(ct, rt.getBackendFormat(), sampleCntToCheck);
+}
+
 bool GrGLCaps::isFormatRenderable(const GrBackendFormat& format, int sampleCount) const {
     if (format.textureType() == GrTextureType::kRectangle && !this->rectangleTextureSupport()) {
         return false;
@@ -4489,6 +4503,19 @@ bool GrGLCaps::isFormatRenderable(const GrBackendFormat& format, int sampleCount
         return false;
     }
     return this->isFormatRenderable(format.asGLFormat(), sampleCount);
+}
+
+bool GrGLCaps::isRenderTargetRenderable(const GrBackendRenderTarget& rt) const {
+    int sampleCntToCheck;
+    GrGLFramebufferInfo fbi;
+    if (rt.getGLFramebufferInfo(&fbi) && fbi.fFBOID == 0) {
+        // FBO0 has different multisampling rules than offscreen render targets. If the user wrapped
+        // FBO0 and told us it's multisampled, just trust that the msaa is valid.
+        sampleCntToCheck = 1;
+    } else {
+        sampleCntToCheck = rt.sampleCnt();
+    }
+    return this->isFormatRenderable(rt.getBackendFormat(), sampleCntToCheck);
 }
 
 int GrGLCaps::getRenderTargetSampleCount(int requestedCount, GrGLFormat format) const {

--- a/src/gpu/gl/GrGLCaps.h
+++ b/src/gpu/gl/GrGLCaps.h
@@ -125,7 +125,10 @@ public:
 
     bool isFormatAsColorTypeRenderable(GrColorType ct, const GrBackendFormat& format,
                                        int sampleCount = 1) const override;
+    bool isRenderTargetAsColorTypeRenderable(GrColorType,
+                                             const GrBackendRenderTarget&) const override;
     bool isFormatRenderable(const GrBackendFormat& format, int sampleCount) const override;
+    bool isRenderTargetRenderable(const GrBackendRenderTarget&) const override;
     bool isFormatRenderable(GrGLFormat format, int sampleCount) const {
         return sampleCount <= this->maxRenderTargetSampleCount(format);
     }

--- a/src/gpu/gl/GrGLGpu.cpp
+++ b/src/gpu/gl/GrGLGpu.cpp
@@ -784,12 +784,19 @@ sk_sp<GrRenderTarget> GrGLGpu::onWrapBackendRenderTarget(const GrBackendRenderTa
         return nullptr;
     }
 
-    const auto format = backendRT.getBackendFormat().asGLFormat();
-    if (!this->glCaps().isFormatRenderable(format, backendRT.sampleCnt())) {
+    if (!this->glCaps().isRenderTargetRenderable(backendRT)) {
         return nullptr;
     }
 
-    int sampleCount = this->glCaps().getRenderTargetSampleCount(backendRT.sampleCnt(), format);
+    const auto format = backendRT.getBackendFormat().asGLFormat();
+    int sampleCount;
+    if (info.fFBOID == 0) {
+        // FBO0 has different multisampling rules than offscreen render targets. If the user wrapped
+        // FBO0 and told us it's multisampled, just trust the provided sample count.
+        sampleCount = backendRT.sampleCnt();
+    } else {
+        sampleCount = this->glCaps().getRenderTargetSampleCount(backendRT.sampleCnt(), format);
+    }
 
     GrGLRenderTarget::IDs rtIDs;
     if (sampleCount <= 1) {

--- a/src/image/SkSurface_Gpu.cpp
+++ b/src/image/SkSurface_Gpu.cpp
@@ -579,7 +579,7 @@ bool validate_backend_render_target(const GrCaps* caps, const GrBackendRenderTar
         return false;
     }
 
-    if (!caps->isFormatAsColorTypeRenderable(grCT, rt.getBackendFormat(), rt.sampleCnt())) {
+    if (!caps->isRenderTargetAsColorTypeRenderable(grCT, rt)) {
         return false;
     }
 


### PR DESCRIPTION
GLES2 doesn't support MSAA FBOs, so GrCaps thought it was supposed to
reject an MSAA wrapper on FBO0. This actually isn't correct. In GLES2,
FBO0 can still be multisampled.